### PR TITLE
fix: resolve TypeScript path alias resolution bug preventing app startup after build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "boilerplate-express-nodejs-typescript",
+  "name": "stokreal-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "boilerplate-express-nodejs-typescript",
+      "name": "stokreal-backend",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -23,6 +23,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.0.1",
+        "module-alias": "^2.2.3",
         "morgan": "^1.10.0",
         "nodemailer": "^6.9.7",
         "pg": "^8.11.3",
@@ -51,6 +52,7 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
+        "tsc-alias": "^1.8.16",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.3.3"
       },
@@ -4005,6 +4007,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/getopts": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
@@ -5693,6 +5708,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/module-alias": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
+      "license": "MIT"
+    },
     "node_modules/morgan": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
@@ -5741,6 +5762,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6244,6 +6279,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -6419,6 +6467,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6557,6 +6615,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve.exports": {
@@ -7461,6 +7529,38 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/tsc-alias": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/tsconfig": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Backend API untuk aplikasi StokReal - Manajemen Stok untuk Warung & Toko Kelontong. Fitur utama: pencarian produk cerdas, manajemen stok, notifikasi WhatsApp, dan import Excel.",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc-alias",
     "start": "node dist/index.js",
     "dev": "ts-node-dev --respawn --transpile-only -r tsconfig-paths/register src/index.ts",
     "lint": "eslint src/**/*.ts",
@@ -53,6 +53,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.0.1",
+    "module-alias": "^2.2.3",
     "morgan": "^1.10.0",
     "nodemailer": "^6.9.7",
     "pg": "^8.11.3",
@@ -81,10 +82,22 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
+    "tsc-alias": "^1.8.16",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "_moduleAliases": {
+    "@": "dist",
+    "@config": "dist/config",
+    "@controllers": "dist/controllers",
+    "@middleware": "dist/middleware",
+    "@models": "dist/models",
+    "@routes": "dist/routes",
+    "@services": "dist/services",
+    "@utils": "dist/utils",
+    "@types": "dist/types"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ import dotenv from 'dotenv';
 // Load environment variables first, before any other imports
 dotenv.config();
 
+// Register module aliases for runtime
+import 'module-alias/register';
+
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';


### PR DESCRIPTION
## Description
This pull request fixes a critical bug where the application failed to start after successful build due to unresolved TypeScript path aliases. The issue was caused by the TypeScript compiler not converting `@/` path aliases to relative paths during build, leaving unresolved module references in the compiled JavaScript code.

## Key Changes

### Package.json Updates
- **Modified build script**: Changed from `"build": "tsc"` to `"build": "tsc && tsc-alias"` to handle path alias conversion during build process
- **Added module-alias dependency**: Installed `module-alias@^2.2.3` for runtime path alias resolution
- **Added tsc-alias dev dependency**: Installed `tsc-alias@^1.8.16` for build-time path alias processing
- **Added _moduleAliases configuration**: Configured path mappings for all `@/` aliases to point to `dist/` directory

**Before:**
```json
"scripts": {
  "build": "tsc",
  "start": "node dist/index.js"
}
```

**After:**
```json
"scripts": {
  "build": "tsc && tsc-alias",
  "start": "node dist/index.js"
},
"_moduleAliases": {
  "@": "dist",
  "@config": "dist/config",
  "@controllers": "dist/controllers",
  "@middleware": "dist/middleware",
  "@models": "dist/models",
  "@routes": "dist/routes",
  "@services": "dist/services",
  "@utils": "dist/utils",
  "@types": "dist/types"
}
```

### Src/index.ts Updates
- **Added module-alias registration**: Added `import 'module-alias/register';` at the top of the file to enable runtime path alias resolution

**Before:**
```typescript
import dotenv from 'dotenv';
dotenv.config();
import express from 'express';
```

**After:**
```typescript
import dotenv from 'dotenv';
dotenv.config();
// Register module aliases for runtime
import 'module-alias/register';
import express from 'express';
```

## Impact Analysis

### Before Fix
- ✅ `npm run build` succeeded
- ❌ `npm run start` failed with error: `Cannot find module '@/middleware/errorHandler'`
- ❌ Application could not start in production mode
- ❌ All path aliases (`@/middleware/*`, `@/config/*`, etc.) were unresolved

### After Fix
- ✅ `npm run build` succeeds with path alias conversion
- ✅ `npm run start` succeeds and server starts normally
- ✅ Database connection established successfully
- ✅ Server runs on port 3001 with all middleware loaded
- ✅ All path aliases resolve correctly at runtime

## Rationale for Changes
This fix addresses a critical deployment blocker where the application could not start after build completion. The solution implements a dual-layer approach: `tsc-alias` handles build-time path conversion while `module-alias` provides runtime fallback, ensuring compatibility across different deployment scenarios and Node.js environments.

## Type of Changes
- [x] Bug fix: Fixes a critical startup bug
- [ ] New Feature: Adds a new feature to the project
- [ ] Documentation: Adds or updates documentation
- [ ] Refactoring: Code improvement without changing functionality

## Manual Testing Steps

### Prerequisites
1. Ensure Node.js v18+ is installed
2. Ensure all dependencies are installed: `npm install`
3. Ensure database is configured (optional for testing)

### Test Steps
1. **Clean Build Test**
   ```bash
   rm -rf dist/
   npm run build
   ```
   **Expected**: Build completes without errors

2. **Start Application Test**
   ```bash
   npm run start
   ```
   **Expected**: Server starts successfully with logs:
   ```
   [INFO] Database connected successfully
   [INFO] Server is running on port 3001
   [INFO] Environment: development
   [INFO] Health check available at: http://localhost:3001/health
   ```

3. **Health Check Test**
   ```bash
   curl http://localhost:3001/health
   ```
   **Expected**: Returns JSON response with status "OK"

4. **Path Alias Resolution Test**
   - Verify all imports using `@/` work correctly
   - Check that middleware, routes, and services load without errors
   - Confirm no "Cannot find module" errors in logs

5. **Production Build Test**
   ```bash
   NODE_ENV=production npm run build
   NODE_ENV=production npm run start
   ```
   **Expected**: Application starts successfully in production mode

### Rollback Test
1. Remove `tsc-alias` from build script
2. Remove `module-alias/register` import
3. Run `npm run build && npm run start`
4. **Expected**: Original error should reappear, confirming the fix is necessary

## Known Issues and Future Improvements
- **Build Performance**: The addition of `tsc-alias` adds a small overhead to the build process. Consider implementing build caching strategies for larger projects.

- **Development vs Production Parity**: While the fix works for both environments, consider implementing different build strategies for development (using ts-node-dev with tsconfig-paths) vs production (using compiled code with module-alias).

- **Path Alias Maintenance**: As the project grows, ensure all new path aliases are added to both `tsconfig.json` paths and `package.json` _moduleAliases to maintain consistency.